### PR TITLE
Support onPayment and SessionPaymentOnHold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,24 @@
+## [Unreleased]
+
+### Added
+
+ - Support embed with `onPayment` event handler.
+ - *Deprecate* support for embed with `onPaymentAuthorized` event handler.
+
+## [0.0.11]
+
+### Added
+
+ - Support for language updates and embedResult page
+
+## [0.0.10]
+
+### Changed
+
+ - Use correct callback names in README examples
+
+## [0.0.9]
+
+### Added
+
+ - sdk version as url query parameter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [Unreleased]
+## [0.0.12]
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ _The checkout sdk will add a polyfill for promises if the browser does not suppo
             onSession: function(event, checkout) {
                 console.log("session", event.session);
             },
-            onPaymentAuthorized: function(event, checkout) {
+            onPayment: function(event, checkout) {
                 console.log("transaction_id", event.transaction_id);
                 console.log("href", event.href);
                 checkout.destroy();
@@ -95,7 +95,7 @@ import {
     dintero,
     SessionLoaded,
     SessionUpdated,
-    SessionPaymentAuthorized,
+    SessionPayment,
     SessionPaymentError,
     SessionCancel,
 } from "@dintero/checkout-web-sdk";
@@ -109,7 +109,7 @@ const checkout = await dintero.embed({
     onSession: (event: SessionLoaded | SessionUpdated) => {
         console.log("session", event.session);
     },
-    onPaymentAuthorized: (event: SessionPaymentAuthorized) => {
+    onPayment: (event: SessionPayment) => {
         console.log("transaction_id", event.transaction_id);
         console.log("href", event.href);
         checkout.destroy();
@@ -130,7 +130,7 @@ const checkout = await dintero.embed({
 The user is redirected to the Dintero Checkout to complete payment.
 
 ```ts
-import { dintero, SessionPaymentAuthorized } from "dintero-checkout-web-sdk";
+import { dintero } from "dintero-checkout-web-sdk";
 
 const checkout = dintero.redirect({
     sid: "T11223344.<short-uuid>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dintero/checkout-web-sdk",
-    "version": "0.0.11",
+    "version": "0.0.12",
     "description": "Dintero Checkout SDK for web frontends",
     "source": "src/dintero-checkout-web-sdk.ts",
     "browser": "dist/checkout-web-sdk.js",

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -5,6 +5,7 @@ export enum CheckoutEvents {
     SessionLoaded = "SessionLoaded",
     SessionUpdated = "SessionUpdated",
     SessionCancel = "SessionCancel",
+    SessionPaymentOnHold = "SessionPaymentOnHold",
     SessionPaymentAuthorized = "SessionPaymentAuthorized",
     SessionPaymentError = "SessionPaymentError",
 }
@@ -32,12 +33,21 @@ export type SessionCancel = {
     href: string;
 };
 
+export type SessionPaymentOnHold = {
+    type: CheckoutEvents.SessionPaymentOnHold;
+    transaction_id: string;
+    merchant_reference: string;
+    href: string;
+};
+
 export type SessionPaymentAuthorized = {
     type: CheckoutEvents.SessionPaymentAuthorized;
     transaction_id: string;
     merchant_reference: string;
     href: string;
 };
+
+export type SessionPayment = SessionPaymentAuthorized | SessionPaymentOnHold;
 
 export type SessionPaymentError = {
     type: CheckoutEvents.SessionPaymentError;
@@ -50,5 +60,6 @@ export type SessionEvent =
     | SessionLoaded
     | SessionUpdated
     | SessionCancel
+    | SessionPaymentOnHold
     | SessionPaymentAuthorized
     | SessionPaymentError;

--- a/src/dintero-checkout-web-sdk.ts
+++ b/src/dintero-checkout-web-sdk.ts
@@ -33,12 +33,12 @@ export interface DinteroCheckoutOptions {
 
 export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
     container: HTMLDivElement;
-    onPaymentAuthorized?: (
-        event: SessionPaymentAuthorized,
-        checkout: DinteroCheckoutInstance
-    ) => void;
     onPayment?: (
         event: SessionPaymentAuthorized | SessionPaymentOnHold,
+        checkout: DinteroCheckoutInstance
+    ) => void;
+    onPaymentAuthorized?: (
+        event: SessionPaymentAuthorized,
         checkout: DinteroCheckoutInstance
     ) => void;
     onSession?: (
@@ -181,9 +181,9 @@ export const embed = async (
                 : followHref,
         },
         {
-            eventTypes: onPayment? []: [CheckoutEvents.SessionPaymentAuthorized],
-            handler: onPaymentAuthorized
-                ? handleWithResult(sid, endpoint, onPaymentAuthorized)
+            eventTypes: [CheckoutEvents.SessionPaymentAuthorized],
+            handler: onPaymentAuthorized || onPayment
+                ? handleWithResult(sid, endpoint, onPaymentAuthorized || onPayment)
                 : followHref,
         },
         {

--- a/src/dintero-checkout-web-sdk.ts
+++ b/src/dintero-checkout-web-sdk.ts
@@ -8,6 +8,7 @@ import {
     SessionLoaded,
     SessionUpdated,
     SessionCancel,
+    SessionPaymentOnHold,
     SessionPaymentAuthorized,
     SessionPaymentError,
 } from "./checkout";
@@ -34,6 +35,10 @@ export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
     container: HTMLDivElement;
     onPaymentAuthorized?: (
         event: SessionPaymentAuthorized,
+        checkout: DinteroCheckoutInstance
+    ) => void;
+    onPayment?: (
+        event: SessionPaymentAuthorized | SessionPaymentOnHold,
         checkout: DinteroCheckoutInstance
     ) => void;
     onSession?: (
@@ -123,6 +128,7 @@ export const embed = async (
         endpoint = "https://checkout.dintero.com",
         onSession,
         onSessionCancel,
+        onPayment,
         onPaymentAuthorized,
         onPaymentError,
         onSessionNotFound,
@@ -169,7 +175,13 @@ export const embed = async (
             ],
         },
         {
-            eventTypes: [CheckoutEvents.SessionPaymentAuthorized],
+            eventTypes: [CheckoutEvents.SessionPaymentOnHold],
+            handler: onPayment
+                ? handleWithResult(sid, endpoint, onPayment)
+                : followHref,
+        },
+        {
+            eventTypes: onPayment? []: [CheckoutEvents.SessionPaymentAuthorized],
             handler: onPaymentAuthorized
                 ? handleWithResult(sid, endpoint, onPaymentAuthorized)
                 : followHref,

--- a/src/dintero-checkout-web-sdk.ts
+++ b/src/dintero-checkout-web-sdk.ts
@@ -37,6 +37,9 @@ export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
         event: SessionPaymentAuthorized | SessionPaymentOnHold,
         checkout: DinteroCheckoutInstance
     ) => void;
+    /**
+     * @deprecated Since version 0.0.1. Will be deleted in version 1.0.0. Use onPayment instead.
+     */
     onPaymentAuthorized?: (
         event: SessionPaymentAuthorized,
         checkout: DinteroCheckoutInstance

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -280,85 +280,46 @@ describe("dintero.embed", () => {
         getSessionUrlStub.restore();
     });
 
-    it("listens to onPayment messages", async () => {
-        const windowLocationAssignStub = sinon.stub(
-            url,
-            "windowLocationAssign"
-        );
-        const script = `
+    ["SessionPaymentAuthorized", "SessionPaymentOnHold"].forEach((type) => {
+        it(`listens to ${type} messages`, async () => {
+            const windowLocationAssignStub = sinon.stub(
+                url,
+                "windowLocationAssign",
+            );
+            const script = `
             emit({
-                type: "SessionPaymentOnHold",
+                type: "${type}",
                 href: "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>",
                 transaction_id: "<transaction_id>",
                 merchant_reference: "test-1",
             });
         `;
-        const getSessionUrlStub = sinon
-            .stub(url, "getSessionUrl")
-            .callsFake((options: url.SessionUrlOptions) =>
-                getHtmlBlobUrl(options, script)
+            const getSessionUrlStub = sinon
+                .stub(url, "getSessionUrl")
+                .callsFake((options: url.SessionUrlOptions) =>
+                    getHtmlBlobUrl(options, script),
+                );
+
+            await new Promise((resolve, reject) => {
+                windowLocationAssignStub.callsFake(() => {
+                    resolve();
+                });
+                const container = document.createElement("div");
+                document.body.appendChild(container);
+                dintero.embed({
+                    sid: "<session_id>",
+                    container,
+                    endpoint: "http://localhost:9999",
+                });
+            });
+
+            sinon.assert.alwaysCalledWithExactly(
+                windowLocationAssignStub,
+                "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>",
             );
-
-        await new Promise((resolve, reject) => {
-            windowLocationAssignStub.callsFake(() => {
-                resolve();
-            });
-            const container = document.createElement("div");
-            document.body.appendChild(container);
-            dintero.embed({
-                sid: "<session_id>",
-                container,
-                endpoint: "http://localhost:9999",
-            });
+            getSessionUrlStub.restore();
+            windowLocationAssignStub.restore();
         });
-
-        sinon.assert.alwaysCalledWithExactly(
-            windowLocationAssignStub,
-            "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>"
-        );
-        getSessionUrlStub.restore();
-        windowLocationAssignStub.restore();
-    });
-
-
-    it("listens to onPaymentAuthorized messages", async () => {
-        const windowLocationAssignStub = sinon.stub(
-            url,
-            "windowLocationAssign"
-        );
-        const script = `
-            emit({
-                type: "SessionPaymentAuthorized",
-                href: "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>",
-                transaction_id: "<transaction_id>",
-                merchant_reference: "test-1",
-            });
-        `;
-        const getSessionUrlStub = sinon
-            .stub(url, "getSessionUrl")
-            .callsFake((options: url.SessionUrlOptions) =>
-                getHtmlBlobUrl(options, script)
-            );
-
-        await new Promise((resolve, reject) => {
-            windowLocationAssignStub.callsFake(() => {
-                resolve();
-            });
-            const container = document.createElement("div");
-            document.body.appendChild(container);
-            dintero.embed({
-                sid: "<session_id>",
-                container,
-                endpoint: "http://localhost:9999",
-            });
-        });
-
-        sinon.assert.alwaysCalledWithExactly(
-            windowLocationAssignStub,
-            "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>"
-        );
-        getSessionUrlStub.restore();
-        windowLocationAssignStub.restore();
     });
 
     it("listens to onSessionPaymentError messages", async () => {


### PR DESCRIPTION
- [x] support new SessionPaymentOnHold event in case where the transaction was created with status `ON_HOLD`
- [x] add `onPayment` handler that accept multiple kinds of SessionPayment events
    - SessionPaymentOnHold
    - SessionPaymentAuthorized
- [x] deprecate the current `onPaymentAuthorized` handler

ref: https://github.com/Dintero/checkout-service/issues/1044