### PR TITLE
Add version 0.0.13 since wrong build was published to NPM for 0.0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,30 @@
+## [0.0.13]
+
+### Changed
+
+-No changes but the build published to NPM for version `0.0.12` vas outdated.
+
 ## [0.0.12]
 
 ### Added
 
- - Support embed with `onPayment` event handler.
- - *Deprecate* support for embed with `onPaymentAuthorized` event handler.
+-   Support embed with `onPayment` event handler.
+-   _Deprecate_ support for embed with `onPaymentAuthorized` event handler.
 
 ## [0.0.11]
 
 ### Added
 
- - Support for language updates and embedResult page
+-   Support for language updates and embedResult page
 
 ## [0.0.10]
 
 ### Changed
 
- - Use correct callback names in README examples
+-   Use correct callback names in README examples
 
 ## [0.0.9]
 
 ### Added
 
- - sdk version as url query parameter
+-   sdk version as url query parameter

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install @dintero/checkout-web-sdk
 Load the Dintero Checkout SDK in a script tag on your site.
 
 ```
-<script src="https://unpkg.com/@dintero/checkout-web-sdk@0.0.12/dist/checkout-web-sdk.umd.js" integrity="sha384-5O24oFt5onxdX5Oy89p2BiolScIILUAxKz7U3niumoIfkFQmVGY8N2DiqK5Ye7VL"></script>
+<script src="https://unpkg.com/@dintero/checkout-web-sdk@0.0.13/dist/checkout-web-sdk.umd.js" integrity="sha384-sM9iYAp4hUFxf/0dZeDdKHrK0drTxFo+w4Of3CAt8QUFHzkaE1ZOgQZUOloi6b6+"></script>
 ```
 
 ## Using the SDK for an embedded checkout

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@dintero/checkout-web-sdk",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@dintero/checkout-web-sdk",
-    "version": "0.0.12",
+    "version": "0.0.13",
     "description": "Dintero Checkout SDK for web frontends",
     "source": "src/dintero-checkout-web-sdk.ts",
     "browser": "dist/checkout-web-sdk.js",


### PR DESCRIPTION
Ref. https://github.com/Dintero/Dintero.Checkout.Web.SDK/pull/4