### PR TITLE
Bump dot-prop from 4.1.1 to 5.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1684,22 +1684,10 @@
                 }
             }
         },
-        "css-unit-converter": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/css-unit-converter/-/css-unit-converter-1.1.1.tgz",
-            "integrity": "sha1-2bkoGtz9jO2TW9urqDeGiX9k6ZY=",
-            "dev": true
-        },
         "css-what": {
             "version": "3.2.1",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-3.2.1.tgz",
             "integrity": "sha512-WwOrosiQTvyms+Ti5ZC5vGEK0Vod3FTt1ca+payZqvKuGJF+dq7bG63DstxtN0dpm6FxY27a/zS3Wten+gEtGw==",
-            "dev": true
-        },
-        "cssesc": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-            "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg==",
             "dev": true
         },
         "cssnano": {
@@ -1992,12 +1980,20 @@
             }
         },
         "dot-prop": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+            "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
             "dev": true,
             "requires": {
-                "is-obj": "^1.0.0"
+                "is-obj": "^2.0.0"
+            },
+            "dependencies": {
+                "is-obj": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+                    "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+                    "dev": true
+                }
             }
         },
         "duplexer": {
@@ -3194,12 +3190,6 @@
             "requires": {
                 "kind-of": "^3.0.2"
             }
-        },
-        "is-obj": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-            "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
-            "dev": true
         },
         "is-plain-obj": {
             "version": "1.1.0",
@@ -4877,22 +4867,41 @@
             }
         },
         "postcss-calc": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.1.tgz",
-            "integrity": "sha512-oXqx0m6tb4N3JGdmeMSc/i91KppbYsFZKdH0xMOqK8V1rJlzrKlTdokz8ozUXLVejydRN6u2IddxpcijRj2FqQ==",
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-7.0.2.tgz",
+            "integrity": "sha512-rofZFHUg6ZIrvRwPeFktv06GdbDYLcGqh9EwiMutZg+a0oePCCw1zHOEiji6LCpyRcjTREtPASuUqeAvYlEVvQ==",
             "dev": true,
             "requires": {
-                "css-unit-converter": "^1.1.1",
-                "postcss": "^7.0.5",
-                "postcss-selector-parser": "^5.0.0-rc.4",
-                "postcss-value-parser": "^3.3.1"
+                "postcss": "^7.0.27",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.0.2"
             },
             "dependencies": {
-                "postcss-value-parser": {
-                    "version": "3.3.1",
-                    "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz",
-                    "integrity": "sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==",
+                "postcss": {
+                    "version": "7.0.32",
+                    "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.32.tgz",
+                    "integrity": "sha512-03eXong5NLnNCD05xscnGKGDZ98CyzoqPSMjOe6SuoQY7Z2hIj0Ld1g/O/UQRuOle2aRtiIRDg9tDcTGAkLfKw==",
+                    "dev": true,
+                    "requires": {
+                        "chalk": "^2.4.2",
+                        "source-map": "^0.6.1",
+                        "supports-color": "^6.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
                     "dev": true
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
                 }
             }
         },
@@ -5338,12 +5347,12 @@
             },
             "dependencies": {
                 "postcss-selector-parser": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+                    "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
                     "dev": true,
                     "requires": {
-                        "dot-prop": "^4.1.1",
+                        "dot-prop": "^5.2.0",
                         "indexes-of": "^1.0.1",
                         "uniq": "^1.0.1"
                     }
@@ -5429,12 +5438,12 @@
             },
             "dependencies": {
                 "postcss-selector-parser": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+                    "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
                     "dev": true,
                     "requires": {
-                        "dot-prop": "^4.1.1",
+                        "dot-prop": "^5.2.0",
                         "indexes-of": "^1.0.1",
                         "uniq": "^1.0.1"
                     }
@@ -5856,14 +5865,22 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-            "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.2.tgz",
+            "integrity": "sha512-36P2QR59jDTOAiIkqEprfJDsoNrvwFei3eCqKd1Y0tUsBimsq39BLp7RD+JWny3WgB1zGhJX8XVePwm9k4wdBg==",
             "dev": true,
             "requires": {
-                "cssesc": "^2.0.0",
+                "cssesc": "^3.0.0",
                 "indexes-of": "^1.0.1",
                 "uniq": "^1.0.1"
+            },
+            "dependencies": {
+                "cssesc": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+                    "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+                    "dev": true
+                }
             }
         },
         "postcss-svgo": {
@@ -8549,12 +8566,12 @@
             },
             "dependencies": {
                 "postcss-selector-parser": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.1.tgz",
-                    "integrity": "sha1-T4dfSvsMllc9XPTXQBGu4lCn6GU=",
+                    "version": "3.1.2",
+                    "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-3.1.2.tgz",
+                    "integrity": "sha512-h7fJ/5uWuRVyOtkO45pnt1Ih40CEleeyCHzipqAZO2e5H20g25Y48uYnFUiShvY4rZWNJ/Bib/KVPmanaCtOhA==",
                     "dev": true,
                     "requires": {
-                        "dot-prop": "^4.1.1",
+                        "dot-prop": "^5.2.0",
                         "indexes-of": "^1.0.1",
                         "uniq": "^1.0.1"
                     }


### PR DESCRIPTION
Bump dependencies that has a transitive dependency to
dot-prop

 - postcss-calc
 - postcss-selector-parser

Fixes: CVE-2020-8116