### PR TITLE
feat(lock): Add callback function to onSessionLocked

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,9 @@ _The checkout sdk will add a polyfill for promises if the browser does not suppo
                 console.log("href", event.href);
                 checkout.destroy();
             },
-            onSessionLocked: function(event, checkout) {
+            onSessionLocked: function(event, checkout, callback) {
                 console.log("pay_lock_id", event.pay_lock_id);
+                callback(); // refresh session
             },
             onSessionLockFailed: function(event, checkout) {
                 console.log("session lock failed");
@@ -132,6 +133,7 @@ const checkout = await embed({
     },
     onSessionLocked: (event, checkout) => {
         console.log("pay_lock_id", event.pay_lock_id);
+        callback(); // refresh session
     },
     onSessionLockFailed: (event, checkout) => {
         console.log("session lock failed");
@@ -194,6 +196,15 @@ After updating the session, call refreshSession on the checkout object:
 
 ```js
 checkout.refreshSession();
+```
+
+or use the callback in `onSessionLocked`:
+
+```js
+onSessionLocked: (event, checkout) => {
+    console.log("pay_lock_id", event.pay_lock_id);
+    callback(); // refresh session
+}
 ```
 
 Editing and paying in the checkout is enabled again.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ const checkout = await embed({
         console.log("href", event.href);
         checkout.destroy();
     },
-    onSessionLocked: (event, checkout) => {
+    onSessionLocked: (event, checkout, callback) => {
         console.log("pay_lock_id", event.pay_lock_id);
         callback(); // refresh session
     },

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ checkout.refreshSession();
 or use the callback in `onSessionLocked`:
 
 ```js
-onSessionLocked: (event, checkout) => {
+onSessionLocked: (event, checkout, callback) => {
     console.log("pay_lock_id", event.pay_lock_id);
     callback(); // refresh session
 }

--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -54,6 +54,7 @@ export type SessionPaymentAuthorized = {
 export type SessionLocked = {
     type: CheckoutEvents.SessionLocked;
     pay_lock_id: string;
+    callback: () => void;
 };
 
 export type SessionLockFailed = {
@@ -76,6 +77,7 @@ export interface SessionValidationCallback {
 }
 
 export type WrappedValidateSession = Pick<ValidateSession, "type" | "session">;
+export type WrappedSessionLocked = Pick<SessionLocked, "type" | "pay_lock_id">;
 
 export type SessionPayment = SessionPaymentAuthorized | SessionPaymentOnHold;
 
@@ -93,7 +95,7 @@ export type SessionEvent =
     | SessionPaymentOnHold
     | SessionPaymentAuthorized
     | SessionPaymentError
-    | SessionLocked
+    | WrappedSessionLocked
     | SessionLockFailed
     | ActivePaymentProductType
     | WrappedValidateSession;

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,7 +79,8 @@ export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
     ) => void;
     onSessionLocked?: (
         event: SessionLocked,
-        checkout: DinteroCheckoutInstance
+        checkout: DinteroCheckoutInstance,
+        callback: () => void,
     ) => void;
     onSessionLockFailed?: (
         event: SessionLockFailed,
@@ -226,6 +227,15 @@ export const embed = async (
         }
     }
 
+    const wrappedOnSessionLocked = (
+        event: SessionLocked,
+        checkout: DinteroCheckoutInstance,
+    ) => {
+        if (onSessionLocked) {
+            onSessionLocked(event, checkout, refreshSession);
+        }
+    }
+
     // Create checkout object that wraps the destroy function.
     const checkout: DinteroCheckoutInstance = {
         destroy,
@@ -288,7 +298,7 @@ export const embed = async (
             eventTypes: [CheckoutEvents.SessionNotFound],
         },
         {
-            handler: onSessionLocked as SubscriptionHandler | undefined,
+            handler: wrappedOnSessionLocked as SubscriptionHandler | undefined,
             eventTypes: [CheckoutEvents.SessionLocked],
         },
         {

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -382,6 +382,7 @@ describe("dintero.embed", () => {
         const onSessionResult: {
             event: SessionLocked;
             checkout: dintero.DinteroCheckoutInstance;
+            callback: () => void;
         } = await new Promise((resolve, reject) => {
             const container = document.createElement("div");
             document.body.appendChild(container);
@@ -389,8 +390,8 @@ describe("dintero.embed", () => {
                 sid: "<session_id>",
                 container,
                 endpoint: "http://localhost:9999",
-                onSessionLocked: (event, checkout) => {
-                    resolve({ event, checkout });
+                onSessionLocked: (event, checkout, callback) => {
+                    resolve({ event, checkout, callback });
                 },
             });
         });
@@ -398,6 +399,8 @@ describe("dintero.embed", () => {
         expect(onSessionResult.event.type).to.equal(
             CheckoutEvents.SessionLocked
         );
+
+        expect(onSessionResult.callback).to.be.a('function');
         expect(onSessionResult.event.pay_lock_id).to.equal("plid");
         getSessionUrlStub.restore();
     });


### PR DESCRIPTION
The `onSessionLocked` handler will now get a callback argument for refreshing the session after a successful update
