### PR TITLE
fix: Add correct package version to url

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,6 @@ jobs:
         run: |
           npm install
           npm run test
-          npm run build
 
       - name: Release
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,4 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_PUBLISH_TOKEN }}
-        run: npx semantic-release
+        run: npm semantic-release

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
   "scripts": {
     "build": "preconstruct build",
     "test": "karma start",
-    "semantic-release": "semantic-release"
+    "semantic-release": "semantic-release",
+    "prepublishOnly": "npm run build"
   },
   "private": false,
   "repository": {


### PR DESCRIPTION
The version number is used in the checkout-url as the query parameter `sdk=x.x.x`, but as the version number is first determined during `semantic-release/npm`, it now says `sdk=0.0.0-development`.

Change the release action to run `npm run build` in the `prepublishOnly` hook, as proposed [here](https://semantic-release.gitbook.io/semantic-release/support/faq#how-can-i-use-a-npm-build-script-that-requires-the-package.jsons-version)