### PR TITLE
feat: Return promise for functions lockSession and refreshSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.0.18]
+
+### Changed
+
+-  Changes `lockSession` to return a promise that resolves when the following `SessionLocked` event is returned from the checkout.
+-  Changes `refreshSession` to return a promise that resolves when the following `SessionUpdated` event is returned from the checkout.
+
 ## [0.0.17]
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,32 @@
-## [0.0.18]
+## [0.4.0]
 
 ### Changed
 
 -  Changes `lockSession` to return a promise that resolves when the following `SessionLocked` event is returned from the checkout.
 -  Changes `refreshSession` to return a promise that resolves when the following `SessionUpdated` event is returned from the checkout.
 
+## [0.3.1]
+
+### Bug Fixes
+* Add correct package version to url
+
+## [0.3.0]
+
+### Features
+
+* **lock:** Add callback function to `onSessionLocked`
+
+## [0.2.0]
+
+### Features
+
+* Handling of session validation when embedded
+
 ## [0.0.17]
 
 ### Changed
 
--  Adds `onActivePaymentProductType` callback.  
+-  Adds `onActivePaymentProductType` callback.
 -  Adds `setActivePaymentProductType` function.
 
 ## [0.0.16]

--- a/README.md
+++ b/README.md
@@ -178,8 +178,13 @@ To update an existing Checkout Express-session, follow these steps:
 Call lockSession on the checkout object:
 
 ```js
-checkout.lockSession();
+checkout.lockSession().then(function(sessionLockedEvent){
+    // initiate server side session update and then refresh the session
+});
 ```
+
+`lockSession()` returns a promise that is resolved when the `SessionLocked` event is 
+received from the checkout or rejected if the SessionLockFailed event is received.
 
 When the session is successfully locked, you'll get a callback at `onSessionLocked`.
 If locking the session fails, there will be a callback at `onSessionLockFailed`.
@@ -206,6 +211,9 @@ onSessionLocked: (event, checkout, callback) => {
     callback(); // refresh session
 }
 ```
+
+`refreshSession()` returns a promise that is resolved when the `SessionUpdated`
+event is received from the checkout.
 
 Editing and paying in the checkout is enabled again.
 

--- a/README.md
+++ b/README.md
@@ -180,10 +180,12 @@ Call lockSession on the checkout object:
 ```js
 checkout.lockSession().then(function(sessionLockedEvent){
     // initiate server side session update and then refresh the session
-});
+}).catch(function(sessionLockFailedEvent) {
+    // handle failure to lock
+});;
 ```
 
-`lockSession()` returns a promise that is resolved when the `SessionLocked` event is 
+`lockSession()` returns a promise that is resolved when the `SessionLocked` event is
 received from the checkout or rejected if the SessionLockFailed event is received.
 
 When the session is successfully locked, you'll get a callback at `onSessionLocked`.
@@ -215,7 +217,8 @@ onSessionLocked: (event, checkout, callback) => {
 `refreshSession()` returns a promise that is resolved when the `SessionUpdated`
 event is received from the checkout.
 
-Editing and paying in the checkout is enabled again.
+Editing and paying in the checkout is enabled again when a session without a `pay_lock`
+is loaded by the checkout.
 
 ### Validating session before payment
 

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -827,6 +827,141 @@ describe("dintero.embed", () => {
         getSessionUrlStub.restore();
     });
 
+    it("should return a promise that resolves when calling lockSession and the SessionLocked is received", async () => {
+        const script = `
+            window.setTimeout(function(){
+                emit({
+                    type: "SessionLocked",
+                    pay_lock_id: "plid",
+                });
+            }, 10);
+        `;
+        const getSessionUrlStub = sinon
+            .stub(url, "getSessionUrl")
+            .callsFake((options: url.SessionUrlOptions) =>
+                getHtmlBlobUrl(options, script)
+            );
+
+        const event: any = await new Promise((resolve, reject) => {
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            dintero.embed({
+                sid: "<session_id>",
+                container,
+                endpoint: "http://localhost:9999",
+            }).then((checkout) => {
+                checkout.lockSession().then((lockedEvent)=> {
+                    resolve(lockedEvent);
+                }).catch(() =>{
+                    reject('lockSession() raised unexpected exception')
+                });
+            });
+        });
+        getSessionUrlStub.restore();
+        expect(event).to.not.be.not.undefined;
+    });
+    it("should raise an exception when calling lockSession and the SessionLocked is received", async () => {
+        const script = `
+            window.setTimeout(function(){
+                emit({
+                    type: "SessionLockFailed",
+                });
+            }, 10);
+        `;
+        const getSessionUrlStub = sinon
+            .stub(url, "getSessionUrl")
+            .callsFake((options: url.SessionUrlOptions) =>
+                getHtmlBlobUrl(options, script)
+            );
+
+        const error: any = await new Promise((resolve, reject) => {
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            dintero.embed({
+                sid: "<session_id>",
+                container,
+                endpoint: "http://localhost:9999",
+            }).then((checkout) => {
+                checkout.lockSession().then((lockedEvent)=> {
+                    reject('lockSession() did not raise exception');
+                }).catch(err => {
+                    resolve(err);
+                });
+            });
+        });
+        console.log(error);
+        expect(error).to.not.be.undefined;
+        getSessionUrlStub.restore();
+    });
+
+
+    it("should return a promise that resolves when calling refreshSession and the SessionUpdated is received", async () => {
+        const script = `
+            window.setTimeout(function(){
+                emit({
+                    type: "SessionUpdated",
+                });
+            }, 10);
+        `;
+        const getSessionUrlStub = sinon
+            .stub(url, "getSessionUrl")
+            .callsFake((options: url.SessionUrlOptions) =>
+                getHtmlBlobUrl(options, script)
+            );
+
+        const event: any = await new Promise((resolve, reject) => {
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            dintero.embed({
+                sid: "<session_id>",
+                container,
+                endpoint: "http://localhost:9999",
+            }).then((checkout) => {
+                checkout.refreshSession().then((sessionUpdatedEvent)=> {
+                    resolve(sessionUpdatedEvent);
+                }).catch(() =>{
+                    reject('refreshSession() raised unexpected exception')
+                });
+            });
+        });
+        getSessionUrlStub.restore();
+        expect(event).to.not.be.not.undefined;
+    });
+    it("should raise an exception when calling refreshSession and the SessionNotFound is received", async () => {
+        const script = `
+            window.setTimeout(function(){
+                emit({
+                    type: "SessionNotFound",
+                });
+            }, 10);
+        `;
+        const getSessionUrlStub = sinon
+            .stub(url, "getSessionUrl")
+            .callsFake((options: url.SessionUrlOptions) =>
+                getHtmlBlobUrl(options, script)
+            );
+
+        const error: any = await new Promise((resolve, reject) => {
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            dintero.embed({
+                sid: "<session_id>",
+                container,
+                endpoint: "http://localhost:9999",
+            }).then((checkout) => {
+                checkout.refreshSession().then((lockedEvent)=> {
+                    reject('refreshSession() did not raise exception');
+                }).catch(err => {
+                    resolve(err);
+                });
+            });
+        });
+        console.log(error);
+        expect(error).to.not.be.undefined;
+        getSessionUrlStub.restore();
+    });
+
+
     it("posts ack for received messages", async () => {
         const mid = Math.floor(Math.random() * 1000000000000000000);
         const script = `


### PR DESCRIPTION
-  Changes `lockSession` to return a promise that resolves when the following `SessionLocked` event is returned from the checkout. If a `SessionLockFailed` event is returned from the checkout, the promise is rejected.
-  Changes `refreshSession` to return a promise that resolves when the following `SessionUpdated` event is returned from the checkout. If a `SessionNotFound` event is returned from the checkout, the promise is rejected.


One thing to think about: Maybe the refreshSession event should also fail if the session that was rejected is still locked?