### PR TITLE
fix: Adds allow-popups-to-escape-sandbox to iframe sandbox

### DIFF
--- a/src/createIframeAsync.ts
+++ b/src/createIframeAsync.ts
@@ -32,7 +32,7 @@ export const createIframeAsync = (
     // allow popups is needed to open terms in new window
     iframe.setAttribute(
         "sandbox",
-        "allow-scripts allow-forms allow-same-origin allow-popups"
+        "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
     );
 
     // The download priority of the resource in the <iframe>'s src attribute.


### PR DESCRIPTION
Closes https://github.com/Dintero/checkout/issues/989

Change iframe sandbox properties when embedding checkout so that the walley terms PDF files can be opened.
