### PR TITLE
chore: fix release script by increasing fetch depth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
         with:
-          fetch-depth: 0
+          fetch-depth: 5
 
       - name: Setup Node.js
         uses: actions/setup-node@v2

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ _The checkout sdk will add a polyfill for promises if the browser does not suppo
                 console.log("href", event.href);
                 checkout.destroy();
             },
-            onSessionNotFound: function(event) {
+            onSessionNotFound: function(event, checkout) {
                 console.log("session not found (expired)", event.type);
                 checkout.destroy();
             },
@@ -123,20 +123,20 @@ const checkout = await embed({
     onSession: (event: SessionLoaded | SessionUpdated) => {
         console.log("session", event.session);
     },
-    onPayment: (event: SessionPayment) => {
+    onPayment: (event: SessionPayment, checkout) => {
         console.log("transaction_id", event.transaction_id);
         console.log("href", event.href);
         checkout.destroy();
     },
-    onPaymentError: (event: SessionPaymentError) => {
+    onPaymentError: (event: SessionPaymentError, checkout) => {
         console.log("href", event.href);
         checkout.destroy();
     },
-    onSessionCancel: (event: SessionCancel) => {
+    onSessionCancel: (event: SessionCancel, checkout) => {
         console.log("href", event.href);
         checkout.destroy();
     },
-    onSessionNotFound: (event: SessionNotFound) => {
+    onSessionNotFound: (event: SessionNotFound, checkout) => {
         console.log("session not found (expired)", event.type);
         checkout.destroy();
     },


### PR DESCRIPTION
Pushing tags from shallow clones stopped working at some point. To resolve, use a bigger fetch-depth.

See https://stackoverflow.com/questions/72220249/why-cant-i-push-tags-in-github-workflows-anymore-and-how-do-i-fix-it
