### PR TITLE
feat: adds scroll to iframe top handler

### DIFF
--- a/src/checkout.ts
+++ b/src/checkout.ts
@@ -16,6 +16,7 @@ export enum CheckoutEvents {
 export enum InternalCheckoutEvents {
     HeightChanged = "HeightChanged",
     LanguageChanged = "LanguageChanged",
+    ScrollToTop = "ScrollToTop",
 }
 
 export type SessionNotFound = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,7 +110,7 @@ const followHref: SubscriptionHandler = (event: any): void => {
 /**
  * An event handler that sets height of the iframe.
  */
-const setIframeHeight: SubscriptionHandler = (event: any, checkout): void => {
+const setIframeHeight: SubscriptionHandler = (event: any, checkout: DinteroCheckoutInstance): void => {
     if (event.height || event.height === 0) {
         checkout.iframe.setAttribute(
             "style",
@@ -118,7 +118,27 @@ const setIframeHeight: SubscriptionHandler = (event: any, checkout): void => {
         );
     }
 };
-const setLanguage: SubscriptionHandler = (event: any, checkout): void => {
+
+/**
+ * An event handler that scrolls to the top of the iframe. This is useful when the user
+ * is navigated to another page.
+ */
+ const scrollToIframeTop: SubscriptionHandler = (event: any, checkout: DinteroCheckoutInstance): void => {
+    try {
+        checkout.iframe.scrollIntoView({
+            block: 'start',
+            behavior: 'smooth',
+        });
+    } catch (e){
+        // Ignore erorr silenty bug log it to the console.
+        console.error(e);
+    }
+};
+
+/**
+ * An event handler that sets language in the iframe.
+ */
+const setLanguage: SubscriptionHandler = (event: any, checkout: DinteroCheckoutInstance): void => {
     if (event.language) {
         checkout.language = event.language;
     }
@@ -301,6 +321,10 @@ export const embed = async (
         {
             handler: setIframeHeight,
             eventTypes: [InternalCheckoutEvents.HeightChanged],
+        },
+        {
+            handler: scrollToIframeTop,
+            eventTypes: [InternalCheckoutEvents.ScrollToTop],
         },
         {
             handler: onSession as SubscriptionHandler | undefined,

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -603,6 +603,32 @@ describe("dintero.embed", () => {
         getSessionUrlStub.restore();
     });
 
+
+    it("changes scrolls to top of iframe when iframe tells it to", async () => {
+        const script = `
+            emit({
+                type: "ScrollToTop",
+            });
+        `;
+        const getSessionUrlStub = sinon
+            .stub(url, "getSessionUrl")
+            .callsFake((options: url.SessionUrlOptions) =>
+                getHtmlBlobUrl(options, script)
+            );
+
+        const container = document.createElement("div");
+        document.body.appendChild(container);
+
+        const checkout = await dintero.embed({
+            sid: "<session_id>",
+            container,
+            endpoint: "http://localhost:9999",
+        });
+        await sleep(10);
+        expect(checkout).to.not.be.undefined;
+        getSessionUrlStub.restore();
+    });
+
     it("changes language when iframe changes language", async () => {
         const script = `
             emit({


### PR DESCRIPTION
Adds new internal event "ScrollToTop" so that when the checkout is embedded.

This will allow us to scroll to the top of the iframe before we navigate the user to a 3rd party site.