### PR TITLE
ci(release): Configure GITHUB_TOKEN permission

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+      packages: write
+      issues: write
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Add more permissions to support semantic-release, fixing the release workflow

Rel: https://github.com/Dintero/Dintero.Checkout.Web.SDK/actions/runs/3421841846