### PR TITLE
fix: set allow=payment proptery on iframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.6.0]
+### Changed
+
+- Changes iframe to also have `allow="payment"` property to support Apple Pay when embedded
+
 ## [0.4.0]
 
 ### Changed

--- a/src/createIframeAsync.ts
+++ b/src/createIframeAsync.ts
@@ -35,6 +35,9 @@ export const createIframeAsync = (
         "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
     );
 
+    // Needed for to allow apple pay from iframe
+    iframe.setAttribute("allow", "payment");
+
     // The download priority of the resource in the <iframe>'s src attribute.
     iframe.setAttribute("importance", "high");
 


### PR DESCRIPTION
Rel. https://bugs.webkit.org/show_bug.cgi?id=226345
Rel. https://github.com/WebKit/WebKit/pull/11485
Rel. https://webkit.org/blog/14135/release-notes-for-safari-technology-preview-169/

Updates SDK to set the `allow="payment"` property on the iframe so that Apple Pay will work when the checkout is embedded in an iframe.

Verified that the feature woks in the latest Safari Technology Preview by modifying the embedded payment iframe at https://shop.dintero.com

Some RnD is needed to check if this uses the apple pay file located at shop.dintero.com or checkout.dintero.com but that is out of scope for this change.