### PR TITLE
fix: avoid duplicate invocation of onActivePaymentType

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -379,10 +379,6 @@ export const embed = async (
             eventTypes: [CheckoutEvents.ActivePaymentProductType],
         },
         {
-            handler: onActivePaymentType as SubscriptionHandler | undefined,
-            eventTypes: [CheckoutEvents.ActivePaymentProductType],
-        },
-        {
             handler: wrappedOnValidateSession as SubscriptionHandler | undefined,
             eventTypes: [CheckoutEvents.ValidateSession],
         },


### PR DESCRIPTION
Ref. https://github.com/Dintero/wiki/wiki/incident-reports-2023-08-02-checkout-express-outage

During investigation of the checkout incident I observed that digitroll had a weird singleton to handle double invocations of `onActivePaymentType` when using the SDK. This PR removes the double invocation of the `onActivePaymentType` handler when an event is received by the SDK