### PR TITLE
fix: pop out loaded check different origin

### DIFF
--- a/src/popOut.ts
+++ b/src/popOut.ts
@@ -4,7 +4,12 @@ const WIDTH = Math.min(480, window.screen.width);
 const HEIGHT = Math.min(840, window.screen.height);
 let popOutWindow: undefined | Window;
 
-const createPopOutWindow = (sid:string, url: string, width: number, height: number) => {
+const createPopOutWindow = (
+    sid: string,
+    url: string,
+    width: number,
+    height: number,
+) => {
     return new Promise<Window | undefined>((resolve) => {
         try {
             // Creates a centered pop up window
@@ -17,13 +22,20 @@ const createPopOutWindow = (sid:string, url: string, width: number, height: numb
             const handleAppLoaded = (event: MessageEvent) => {
                 const correctSource = event.source === popOut;
                 const correctOrigin = event.origin === new URL(url).origin;
-                const correctMessage = event.data && event.data.type === "AppLoaded";
+                const correctMessage =
+                    event.data && event.data.type === "AppLoaded";
                 const correctContext = event.data.context === "popOut";
                 const correctSid = event.data.sid === sid;
-                if(correctSource && correctOrigin && correctMessage && correctContext && correctSid) {
+                if (
+                    correctSource &&
+                    correctOrigin &&
+                    correctMessage &&
+                    correctContext &&
+                    correctSid
+                ) {
                     clearTimeout(timeout);
                     resolve(popOut);
-                    window.removeEventListener('message', handleAppLoaded);
+                    window.removeEventListener("message", handleAppLoaded);
                 }
             };
             window.addEventListener("message", handleAppLoaded);
@@ -40,7 +52,6 @@ const createPopOutWindow = (sid:string, url: string, width: number, height: numb
                 console.log("createPopOutWindow timeout");
                 resolve(undefined);
             }, 3000);
-
         } catch (err) {
             resolve(undefined);
         }

--- a/src/popOut.ts
+++ b/src/popOut.ts
@@ -4,28 +4,43 @@ const WIDTH = Math.min(480, window.screen.width);
 const HEIGHT = Math.min(840, window.screen.height);
 let popOutWindow: undefined | Window;
 
-const createPopOutWindow = (url: string, width: number, height: number) => {
+const createPopOutWindow = (sid:string, url: string, width: number, height: number) => {
     return new Promise<Window | undefined>((resolve) => {
         try {
-            // Opens a centered pop up window
+            // Creates a centered pop up window
             const left = window.screenX + (window.outerWidth - width) / 2;
             const top = window.screenY + (window.outerHeight - height) / 2;
             const features = `width=${width},height=${height},left=${left},top=${top},location=no,menubar=no,toolbar=no,status=no`;
-            const popOut = window.open(url, "dintero-checkout", features);
+            let popOut: undefined | Window;
+            let timeout = -1;
+            // Set up listener for application loaded message from pop out window
+            const handleAppLoaded = (event: MessageEvent) => {
+                const correctSource = event.source === popOut;
+                const correctOrigin = event.origin === new URL(url).origin;
+                const correctMessage = event.data && event.data.type === "AppLoaded";
+                const correctContext = event.data.context === "popOut";
+                const correctSid = event.data.sid === sid;
+                if(correctSource && correctOrigin && correctMessage && correctContext && correctSid) {
+                    clearTimeout(timeout);
+                    resolve(popOut);
+                    window.removeEventListener('message', handleAppLoaded);
+                }
+            };
+            window.addEventListener("message", handleAppLoaded);
+            // Open pop out
+            popOut = window.open(url, "dintero-checkout", features);
+            // Check that pop out was opened
             if (!popOut) {
                 console.log("createPopOutWindow no popOut");
                 resolve(undefined);
                 return;
             }
-            const timeout = window.setTimeout(() => {
+            // Trigger timeout if pop out is not loaded
+            timeout = window.setTimeout(() => {
                 console.log("createPopOutWindow timeout");
                 resolve(undefined);
             }, 3000);
-            popOut.addEventListener("load", (event) => {
-                console.log("createPopOutWindow loaded", { popOut, event });
-                clearTimeout(timeout);
-                resolve(popOut);
-            });
+
         } catch (err) {
             resolve(undefined);
         }
@@ -49,7 +64,7 @@ export const openPopOut = async (options: PopOutOptions) => {
 
     // Open popup window
     const url = getPopOutUrl(options);
-    popOutWindow = await createPopOutWindow(url, WIDTH, HEIGHT);
+    popOutWindow = await createPopOutWindow(options.sid, url, WIDTH, HEIGHT);
 
     const focusPopOut = () => {
         if (popOutWindow) {

--- a/src/url.ts
+++ b/src/url.ts
@@ -48,7 +48,7 @@ export const getSessionUrl = (options: SessionUrlOptions): string => {
     // custom endpoints like localhost and PR builds does not support the
     // serverside view flow.
     params.append("sid", sid);
-    return `${endpoint}/?${params.toString()}`;
+    return `${padTralingSlash(endpoint)}?${params.toString()}`;
 };
 
 const padTralingSlash = (endpoint: string) =>
@@ -60,9 +60,6 @@ export const getPopOutUrl = ({
     language,
     shouldCallValidateSession,
 }: SessionUrlOptions) => {
-    if (shouldCallValidateSession) {
-        return `${padTralingSlash(endpoint)}?loader=true`;
-    }
     const params = new URLSearchParams();
     params.append("ui", "fullscreen");
     params.append("role", "pop_out_payment");
@@ -71,5 +68,9 @@ export const getPopOutUrl = ({
     if (language) {
         params.append("language", language);
     }
-    return `${endpoint}/?${params.toString()}`;
+    if (shouldCallValidateSession) {
+        params.append("loader", 'true');
+        return `${padTralingSlash(endpoint)}?${params.toString()}`;
+    }
+    return `${padTralingSlash(endpoint)}?${params.toString()}`;
 };

--- a/src/url.ts
+++ b/src/url.ts
@@ -69,7 +69,7 @@ export const getPopOutUrl = ({
         params.append("language", language);
     }
     if (shouldCallValidateSession) {
-        params.append("loader", 'true');
+        params.append("loader", "true");
         return `${padTralingSlash(endpoint)}?${params.toString()}`;
     }
     return `${padTralingSlash(endpoint)}?${params.toString()}`;


### PR DESCRIPTION
Ref. https://github.com/Dintero/epics/issues/230
Rel. https://github.com/Dintero/checkout/pull/1170

Fixes logic when checking if the checkout pop out has loaded. When the SDK runtime is on a different origin than the checkout we are noe able to add event listeners to the pop out. Instead we now listen for a message posted by the checkout pop out JS runtime when the checkout application is opened so the SDK can know that the pop out has been loaded successfully. 