### PR TITLE
fix(build): include ts declarations in release

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -9,7 +9,7 @@ use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
 the Software, and to permit persons to whom the Software is furnished to do so,
 subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all 
+The above copyright notice and this permission notice shall be included in all
 copies or substantial portions of the Software.
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "umd:main": "dist/dintero-checkout-web-sdk.umd.min.js",
     "unpkg": "dist/dintero-checkout-web-sdk.umd.min.js",
     "types": "dist/dintero-checkout-web-sdk.cjs.d.ts",
+    "files": [
+        "dist"
+    ],
     "preconstruct": {
         "umdName": "dintero"
     },


### PR DESCRIPTION
Updates package.json file so that all the typescript declarations are included in the release.

Changes
- Add `files` entry in `package.json`
- Rename file LISENCE → LICENSE and remove trailing spaces