### PR TITLE
fix(build): add asset to github release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,7 +3,20 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
-        "@semantic-release/github",
-        "@semantic-release/npm"
+
+        [
+            "@semantic-release/npm",
+            {
+                "npmPublish": true,
+                "pkgRoot": ".",
+                "tarballDir": "dist"
+            }
+        ],
+        [
+            "@semantic-release/github",
+            {
+                "assets": "dist/*.tgz"
+            }
+        ]
     ]
 }


### PR DESCRIPTION
Ref. https://dintero.slack.com/archives/G7ESUNQ0Z/p1708678043060989

Change configuration for `semantic-release`. With these changes we
- change order of `npm` and `github` plugins (not sure if needed but it matches the order of when they have an effect better)
- add `npm` plugin configuration so that the tarball from `npm pack` is added to the dist folder
- add `github` plugin configuration with an  `asset` entry that takes all tarballs in the dist folder

See related example in the docs for the npm plugin here https://github.com/semantic-release/npm?tab=readme-ov-file#examples

Docs:
- https://github.com/semantic-release/npm
- https://github.com/semantic-release/github