### PR TITLE
fix(build): use exec plugin for github asset

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -3,19 +3,17 @@
     "plugins": [
         "@semantic-release/commit-analyzer",
         "@semantic-release/release-notes-generator",
-
+        "@semantic-release/npm",
         [
-            "@semantic-release/npm",
+            "@semantic-release/exec",
             {
-                "npmPublish": true,
-                "pkgRoot": ".",
-                "tarballDir": "dist"
+                "publish": "npm pack"
             }
         ],
         [
             "@semantic-release/github",
             {
-                "assets": "dist/*.tgz"
+                "assets": "./*.tgz"
             }
         ]
     ]


### PR DESCRIPTION
Fixes https://github.com/Dintero/Dintero.Checkout.Web.SDK/issues/331
Ref. https://github.com/Dintero/Dintero.Checkout.Web.SDK/pull/330
Rel. https://github.com/semantic-release/npm/issues/535
Rel. https://github.com/Dintero/Dintero.Checkout.Web.SDK/actions/runs/8045967660/job/21972265552

The previous config change did not work as intended. The `npm` plugin for semantic release seems to be running twice and the .tgz is not present in the dist folder, and from the logs it does not even look like the package created contains the actual build files either. Instead of trying to make sense of the npm plugin we try using the `exec` plugin to run `npm pack` before the `github` plugin creates is release.