### PR TITLE
fix(build): add dev dependency & update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
           cache: npm

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@babel/core": "7.23.9",
         "@babel/preset-typescript": "7.23.3",
         "@preconstruct/cli": "2.8.3",
+        "@semantic-release/exec": "6.0.3",
         "@semantic-release/git": "10.0.1",
         "@vitest/browser": "1.3.1",
         "prettier": "3.2.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,6 +1025,18 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-4.0.0.tgz#692810288239637f74396976a9340fbc0aa9f6f9"
   integrity sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==
 
+"@semantic-release/exec@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-6.0.3.tgz#d212fdf19633bdfb553de6cb6c7f8781933224db"
+  integrity sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==
+  dependencies:
+    "@semantic-release/error" "^3.0.0"
+    aggregate-error "^3.0.0"
+    debug "^4.0.0"
+    execa "^5.0.0"
+    lodash "^4.17.4"
+    parse-json "^5.0.0"
+
 "@semantic-release/git@10.0.1":
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/@semantic-release/git/-/git-10.0.1.tgz#c646e55d67fae623875bf3a06a634dd434904498"


### PR DESCRIPTION
Ref. https://github.com/Dintero/Dintero.Checkout.Web.SDK/actions/runs/8061936439
Rel. https://github.com/Dintero/Dintero.Checkout.Web.SDK/pull/332
Rel. https://github.com/Dintero/Dintero.Checkout.Web.SDK/pull/332#pullrequestreview-1902834537

Add new dependency used by build. Also updates build actions from version `@3` to `@4` to handle warnings:
> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-node@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.