### PR TITLE
fix(build): exec config uses publishCmd not publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 5
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: "lts/*"
       - name: Install dependencies, test and lint

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
         [
             "@semantic-release/exec",
             {
-                "publish": "npm pack"
+                "publishCmd": "npm pack"
             }
         ],
         [


### PR DESCRIPTION
Rel. https://github.com/semantic-release/exec
Ref. https://github.com/Dintero/Dintero.Checkout.Web.SDK/actions/runs/8079360268/job/22073598945

Updates release workflow to also use `actions/checkout@v4` and `actions/setup-node@v4`.

Fixes error in configuration for exec:
> [11:07:25 AM] [semantic-release] › ✔  Completed step "publish" of plugin "@semantic-release/exec"
> [11:07:25 AM] [semantic-release] › ℹ  Start step "publish" of plugin "@semantic-release/github"

🤞 this will finally work.