### PR TITLE
feat(embed): Allow hiding test message on creating iframe

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,6 @@ export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
     container: HTMLDivElement;
     popOut?: boolean;
     ui?: "inline" | "fullscreen";
-    hideTestMessage?: boolean;
     onPayment?: (
         event: SessionPaymentAuthorized | SessionPaymentOnHold,
         checkout: DinteroCheckoutInstance,
@@ -513,7 +512,9 @@ export const embed = async (
             ui: options.ui || "inline",
             shouldCallValidateSession: onValidateSession !== undefined,
             popOut,
-            hideTestMessage: options.hideTestMessage || false,
+            ...(options.hasOwnProperty("hideTestMessage") && {
+                hideTestMessage: options["hideTestMessage"],
+            }),
         }),
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ export interface DinteroEmbedCheckoutOptions extends DinteroCheckoutOptions {
     container: HTMLDivElement;
     popOut?: boolean;
     ui?: "inline" | "fullscreen";
+    hideTestMessage?: boolean;
     onPayment?: (
         event: SessionPaymentAuthorized | SessionPaymentOnHold,
         checkout: DinteroCheckoutInstance,
@@ -512,6 +513,7 @@ export const embed = async (
             ui: options.ui || "inline",
             shouldCallValidateSession: onValidateSession !== undefined,
             popOut,
+            hideTestMessage: options.hideTestMessage || false,
         }),
     );
 

--- a/src/url.ts
+++ b/src/url.ts
@@ -17,10 +17,11 @@ export interface SessionUrlOptions {
     ui?: "fullscreen" | "inline";
     shouldCallValidateSession: boolean;
     popOut?: boolean;
+    hideTestMessage?: boolean;
 }
 
 const getSessionUrl = (options: SessionUrlOptions): string => {
-    const { sid, endpoint, language, ui, shouldCallValidateSession, popOut } =
+    const { sid, endpoint, language, ui, shouldCallValidateSession, popOut, hideTestMessage } =
         options;
     if (!endpoint) {
         throw new Error("Invalid endpoint");
@@ -38,6 +39,9 @@ const getSessionUrl = (options: SessionUrlOptions): string => {
     }
     if (popOut) {
         params.append("role", "pop_out_launcher");
+    }
+    if (hideTestMessage) {
+        params.append("hide_test_message", "true");
     }
     if (endpoint === "https://checkout.dintero.com") {
         // Default endpoint will redirect via the view endpoint

--- a/src/url.ts
+++ b/src/url.ts
@@ -21,8 +21,15 @@ export interface SessionUrlOptions {
 }
 
 const getSessionUrl = (options: SessionUrlOptions): string => {
-    const { sid, endpoint, language, ui, shouldCallValidateSession, popOut, hideTestMessage } =
-        options;
+    const {
+        sid,
+        endpoint,
+        language,
+        ui,
+        shouldCallValidateSession,
+        popOut,
+        hideTestMessage,
+    } = options;
     if (!endpoint) {
         throw new Error("Invalid endpoint");
     }

--- a/src/url.ts
+++ b/src/url.ts
@@ -17,19 +17,11 @@ export interface SessionUrlOptions {
     ui?: "fullscreen" | "inline";
     shouldCallValidateSession: boolean;
     popOut?: boolean;
-    hideTestMessage?: boolean;
 }
 
 const getSessionUrl = (options: SessionUrlOptions): string => {
-    const {
-        sid,
-        endpoint,
-        language,
-        ui,
-        shouldCallValidateSession,
-        popOut,
-        hideTestMessage,
-    } = options;
+    const { sid, endpoint, language, ui, shouldCallValidateSession, popOut } =
+        options;
     if (!endpoint) {
         throw new Error("Invalid endpoint");
     }
@@ -47,7 +39,11 @@ const getSessionUrl = (options: SessionUrlOptions): string => {
     if (popOut) {
         params.append("role", "pop_out_launcher");
     }
-    if (hideTestMessage) {
+    if (
+        options.hasOwnProperty("hideTestMessage") &&
+        options["hideTestMessage"] !== undefined &&
+        options["hideTestMessage"] === true
+    ) {
         params.append("hide_test_message", "true");
     }
     if (endpoint === "https://checkout.dintero.com") {

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -711,6 +711,7 @@ describe("dintero.embed", () => {
         expect(onSessionResult.callback).to.not.be.undefined;
         expect(getSessionUrl).toBeCalledWith({
             endpoint,
+            hideTestMessage: false,
             shouldCallValidateSession: true,
             sid,
             ui: "inline",
@@ -737,6 +738,7 @@ describe("dintero.embed", () => {
 
         expect(getSessionUrl).toBeCalledWith({
             endpoint,
+            hideTestMessage: false,
             shouldCallValidateSession: false,
             sid,
             ui: "inline",

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -711,7 +711,6 @@ describe("dintero.embed", () => {
         expect(onSessionResult.callback).to.not.be.undefined;
         expect(getSessionUrl).toBeCalledWith({
             endpoint,
-            hideTestMessage: false,
             shouldCallValidateSession: true,
             sid,
             ui: "inline",
@@ -738,7 +737,6 @@ describe("dintero.embed", () => {
 
         expect(getSessionUrl).toBeCalledWith({
             endpoint,
-            hideTestMessage: false,
             shouldCallValidateSession: false,
             sid,
             ui: "inline",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1025,7 +1025,7 @@
   resolved "https://registry.yarnpkg.com/@semantic-release/error/-/error-4.0.0.tgz#692810288239637f74396976a9340fbc0aa9f6f9"
   integrity sha512-mgdxrHTLOjOddRVYIYDo0fR3/v61GNN1YGkfbrjuIKg/uMgCd+Qzo3UAXJ+woLQQpos4pl5Esuw5A7AoNlzjUQ==
 
-"@semantic-release/exec@^6.0.3":
+"@semantic-release/exec@6.0.3":
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/@semantic-release/exec/-/exec-6.0.3.tgz#d212fdf19633bdfb553de6cb6c7f8781933224db"
   integrity sha512-bxAq8vLOw76aV89vxxICecEa8jfaWwYITw6X74zzlO0mc/Bgieqx9kBRz9z96pHectiTAtsCwsQcUyLYWnp3VQ==


### PR DESCRIPTION
Add support for new checkout url parameter `"hide_test_message"`, useful for demoing purposes.

Resolves https://github.com/Dintero/Dintero.Checkout.Web.SDK/issues/336