### PR TITLE
fix(build): Configure id-token in release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
+      id-token: write
       contents: write
       packages: write
       issues: write


### PR DESCRIPTION
To get the aws credentials we need access to create an id-token.

Fixes: #343
