### PR TITLE
chore(build): Skip snapshot CDN upload for dependabot pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_S3_ASSETS_DEPLOY_ROLE }}
           aws-region: eu-west-1
-          audience: sts.amazonaws.com
 
       - name: Upload to CDN
         uses: ./.github/actions/cdn

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,12 +28,14 @@ jobs:
           yarn run lint
 
       - name: Configure AWS credentials
+        if: github.actor != 'dependabot[bot]'
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.AWS_S3_ASSETS_DEPLOY_ROLE }}
           aws-region: eu-west-1
 
       - name: Upload to CDN
+        if: github.actor != 'dependabot[bot]'
         uses: ./.github/actions/cdn
         with:
           file: "dintero-checkout-web-sdk.umd.min.js"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.AWS_S3_ASSETS_DEPLOY_ROLE }}
           aws-region: eu-west-1
+          audience: sts.amazonaws.com
 
       - name: Upload to CDN
         uses: ./.github/actions/cdn


### PR DESCRIPTION
Github secrets are not visible to pull requests coming from a fork, and in this case dependabot is considered a fork.

As we are not dependent to have the snapshot updated with dependabot's changes, we'll skip these steps for those branches.

Ref: https://github.com/aws-actions/configure-aws-credentials/issues/188#issuecomment-805847804

Ref: https://dintero.slack.com/archives/G7ESUNQ0Z/p1710881795866189

[skip release] as workflow code is not necessary to make a release for