### PR TITLE
fix(embed): iframe sandbox allow allow-top-navigation

### DIFF
--- a/src/createIframeAsync.ts
+++ b/src/createIframeAsync.ts
@@ -32,7 +32,7 @@ export const createIframeAsync = (
     // allow popups is needed to open terms in new window
     iframe.setAttribute(
         "sandbox",
-        "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox",
+        "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox allow-top-navigation",
     );
 
     // Needed for to allow apple pay from iframe


### PR DESCRIPTION
Closes https://github.com/Dintero/Dintero.Checkout.Web.SDK/issues/390

Adds additional sandbox property to iframe.

Verified broken behavior in latest Safari on iPhone in Dintero Demo store when paying via vipps.vipps in embedded iframe. Not sure if vipps started doing something different from before or if a browser update caused this change in behavior.