### PR TITLE
fix(iframe):Adds cross origin clipboard-write for iframe

### DIFF
--- a/src/createIframeAsync.ts
+++ b/src/createIframeAsync.ts
@@ -36,7 +36,7 @@ export const createIframeAsync = (
     );
 
     // Needed for to allow apple pay from iframe
-    iframe.setAttribute("allow", "payment");
+    iframe.setAttribute("allow", "payment; clipboard-write *");
 
     // The download priority of the resource in the <iframe>'s src attribute.
     iframe.setAttribute("importance", "high");


### PR DESCRIPTION
Ref. https://dintero.slack.com/archives/C077QF56GFR/p1732876810127329?thread_ts=1732201122.662639&cid=C077QF56GFR

Update in functionality in checkout requires extended permissions to work in a cross domain iframe. This pull request adds permission `clipboard-write *` to the `iframe` that embeds the checkout.

https://github.com/user-attachments/assets/6aa5de6b-89a7-42c5-b9b6-a1dfe0a17b5e

