### PR TITLE
chore(vitest): Enable browser config option

### DIFF
--- a/.vitest.config.mts
+++ b/.vitest.config.mts
@@ -5,6 +5,8 @@ export default defineConfig({
         browser: {
             provider: "webdriverio",
             name: "chrome",
+            enabled: true,
+            headless: true,
         },
     },
 });

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "scripts": {
         "build": "yarn tsc --noEmit && preconstruct build",
         "lint": "prettier --cache --log-level warn -c --config .prettierrc.yml .",
-        "test": "vitest --config .vitest.config.mts --browser.name=chrome --browser.headless",
+        "test": "vitest --config .vitest.config.mts",
         "semantic-release": "semantic-release",
         "prepublishOnly": "yarn run build"
     },


### PR DESCRIPTION
Remove the extra `--browser.name` and `--browser.headless` arguments
used when running `yarn test`. The browser is now selected from the
`.vitest.config.mts`

> Added `headless` config option to keep the current behaviour, it is
> not needed as `CI=1` will enable it when running test in Github Actions
