### PR TITLE
chore(build): Skip updating github-release when no new release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,11 +48,15 @@ jobs:
           role-to-assume: ${{ secrets.AWS_S3_ASSETS_DEPLOY_ROLE }}
           aws-region: eu-west-1
 
+      - name: Set version number
+        run: echo "VERSION=$(npm pkg get version --workspaces=false | tr -d '"')" >> $GITHUB_ENV
+        shell: bash
+
       - name: Upload to CDN
         uses: ./.github/actions/cdn
         with:
           file: "dintero-checkout-web-sdk.umd.min.js"
           s3-bucket: ${{ secrets.S3_BUCKET }}
           s3-prefix: "pkg/checkout-web-sdk"
-          set-as-latest: true
-          update-github-release: true
+          set-as-latest: ${{ env.VERSION != '0.0.0-development' }}
+          update-github-release: ${{ env.VERSION != '0.0.0-development' }}


### PR DESCRIPTION
#487 fixed the bug of updating github releases and latest when running the pull request build. There is however, still an issue when merging a pull request and it doesn't lead to a new version will update the latest github release and upload the version to latest in the CDN, which we don't want.

Attempting to fix this by adding a conditional