### PR TITLE
fix: increase pop-out timeout

### DIFF
--- a/src/popOut.ts
+++ b/src/popOut.ts
@@ -50,7 +50,7 @@ const createPopOutWindow = (
             timeout = window.setTimeout(() => {
                 console.log("createPopOutWindow timeout");
                 resolve(undefined);
-            }, 3000);
+            }, 10000);
         } catch (err) {
             resolve(undefined);
         }


### PR DESCRIPTION
Ref. https://dintero.slack.com/archives/C077QF56GFR/p1747287900627379?thread_ts=1747029612.693999&cid=C077QF56GFR

Increases the timeout for checkout not loaded from 3 seconds to 10. This primarily exists to have a viable fallback for allowing payment if for some reason we are unable to load the checkout (but still crate the pop out window), or if it is closed immediately after it has been opened before we are able to attach event handlers to the close event.

We might want to follow this up with some additional ux changes, I will have a chat with Robert on monday to see if we could crate some additonal interaction needed before we fall back to showing the options inline.

We could potentially also use the [navigator.connection API](https://developer.mozilla.org/en-US/docs/Web/API/Navigator/connection) to check the network information for the current client and have an even higher timeout? But that API is not supported by all browsers.