### PR TITLE
fix(sdk): endpoint origin as postMessage target 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,6 +236,7 @@ const createPopOutMessageHandler = (
                 checkout.iframe,
                 checkout.options.sid,
                 eventData.language,
+                url.getTargetOrigin(checkout.options.endpoint),
             );
         },
     };
@@ -326,20 +327,32 @@ const showPopOut = async (
             createPopOutMessageHandler(popOutWindow, checkout),
         onClose: () => {
             removeBackdrop();
-            postClosePopOutEvent(checkout.iframe, checkout.options.sid);
+            postClosePopOutEvent(
+                checkout.iframe,
+                checkout.options.sid,
+                url.getTargetOrigin(checkout.options.endpoint),
+            );
             setPopOutButtonDisabled(false);
             checkout.popOutWindow = undefined;
         },
     });
     const { close, focus, popOutWindow } = openPopOutResult;
     if (popOutWindow) {
-        postOpenPopOutEvent(checkout.iframe, checkout.options.sid);
+        postOpenPopOutEvent(
+            checkout.iframe,
+            checkout.options.sid,
+            url.getTargetOrigin(checkout.options.endpoint),
+        );
         // Add pop out window to checkout instance
         checkout.popOutWindow = popOutWindow;
         createBackdrop({ focus, close, event });
         return true;
     } else {
-        postOpenPopOutFailedEvent(checkout.iframe, checkout.options.sid);
+        postOpenPopOutFailedEvent(
+            checkout.iframe,
+            checkout.options.sid,
+            url.getTargetOrigin(checkout.options.endpoint),
+        );
         return false;
     }
 };
@@ -356,7 +369,12 @@ const createPopOutValidationCallback = (
     return (result: SessionValidationCallback) => {
         // Tell the embedded iframe about the validation result so it can show an error message if
         // the validation failed.
-        postValidationResult(checkout.iframe, checkout.options.sid, result);
+        postValidationResult(
+            checkout.iframe,
+            checkout.options.sid,
+            result,
+            url.getTargetOrigin(checkout.options.endpoint),
+        );
         if (result.success && checkout.popOutWindow) {
             // Redirect user to session in pop out window
             checkout.popOutWindow.location.href = url.getPopOutUrl({
@@ -392,7 +410,11 @@ const handlePopOutButtonClick = async (
         // Let the host application validate the payment session before opening checkout.
 
         // Tell the embedded iframe that we are validating the session
-        postValidatePopOutEvent(checkout.iframe, checkout.options.sid);
+        postValidatePopOutEvent(
+            checkout.iframe,
+            checkout.options.sid,
+            url.getTargetOrigin(checkout.options.endpoint),
+        );
 
         // Create callback function added to the SDK event and onValidateSession attributes
         const callback = createPopOutValidationCallback(event, checkout);
@@ -412,10 +434,15 @@ const handlePopOutButtonClick = async (
             );
         } catch (e) {
             console.error(e);
-            postValidationResult(checkout.iframe, checkout.options.sid, {
-                success: false,
-                clientValidationError: "Validation runtime error",
-            });
+            postValidationResult(
+                checkout.iframe,
+                checkout.options.sid,
+                {
+                    success: false,
+                    clientValidationError: "Validation runtime error",
+                },
+                url.getTargetOrigin(checkout.options.endpoint),
+            );
         }
     }
 };
@@ -529,6 +556,10 @@ export const embed = async (
         popOut,
     } = internalOptions;
 
+    // Origin of the checkout endpoint, used as the target origin for all
+    // postMessage calls so messages are only ever delivered to the trusted origin.
+    const targetOrigin = url.getTargetOrigin(endpoint);
+
     let checkout: DinteroCheckoutInstance | undefined;
     const subscriptions: Subscription[] = [];
     let has_delivered_final_event = false;
@@ -632,8 +663,12 @@ export const embed = async (
     const lockSession = () => {
         return promisifyAction(
             () => {
-                postSessionLock(iframe, sid);
-                popOutModule.postPopOutSessionLock(checkout?.popOutWindow, sid);
+                postSessionLock(iframe, sid, targetOrigin);
+                popOutModule.postPopOutSessionLock(
+                    checkout?.popOutWindow,
+                    sid,
+                    targetOrigin,
+                );
             },
             CheckoutEvents.SessionLocked,
             CheckoutEvents.SessionLockFailed,
@@ -643,10 +678,11 @@ export const embed = async (
     const refreshSession = () => {
         return promisifyAction(
             () => {
-                postSessionRefresh(iframe, sid);
+                postSessionRefresh(iframe, sid, targetOrigin);
                 popOutModule.postPopOutSessionRefresh(
                     checkout?.popOutWindow,
                     sid,
+                    targetOrigin,
                 );
             },
             CheckoutEvents.SessionUpdated,
@@ -660,20 +696,26 @@ export const embed = async (
             popOutModule.postPopOutActivePaymentProductType(
                 checkout?.popOutWindow,
                 sid,
+                targetOrigin,
                 paymentProductType,
             );
         } else {
-            postActivePaymentProductType(iframe, sid, paymentProductType);
+            postActivePaymentProductType(
+                iframe,
+                sid,
+                targetOrigin,
+                paymentProductType,
+            );
         }
     };
 
     const submitValidationResult = (result: SessionValidationCallback) => {
-        postValidationResult(iframe, sid, result);
+        postValidationResult(iframe, sid, result, targetOrigin);
         // For pop out we do validation when opening the pop out
     };
 
     const submitAddressCallbackResult = (result: AddressCallbackResult) => {
-        postAddressCallbackResult(iframe, sid, result);
+        postAddressCallbackResult(iframe, sid, result, targetOrigin);
         // For pop out we do validation when opening the pop out
     };
 

--- a/src/popOut.ts
+++ b/src/popOut.ts
@@ -132,10 +132,14 @@ const openPopOut = async (options: PopOutOptions) => {
 const postPopOutSessionLock = (
     popOutWindow: undefined | Window,
     sid: string,
+    targetOrigin: string,
 ) => {
     try {
         if (popOutWindow) {
-            popOutWindow.postMessage({ type: "LockSession", sid }, "*");
+            popOutWindow.postMessage(
+                { type: "LockSession", sid },
+                targetOrigin,
+            );
         }
     } catch (e) {
         console.error(e);
@@ -145,10 +149,14 @@ const postPopOutSessionLock = (
 const postPopOutSessionRefresh = (
     popOutWindow: undefined | Window,
     sid: string,
+    targetOrigin: string,
 ) => {
     try {
         if (popOutWindow) {
-            popOutWindow.postMessage({ type: "RefreshSession", sid }, "*");
+            popOutWindow.postMessage(
+                { type: "RefreshSession", sid },
+                targetOrigin,
+            );
         }
     } catch (e) {
         console.error(e);
@@ -158,6 +166,7 @@ const postPopOutSessionRefresh = (
 const postPopOutActivePaymentProductType = (
     popOutWindow: undefined | Window,
     sid: string,
+    targetOrigin: string,
     paymentProductType?: string,
 ) => {
     try {
@@ -168,7 +177,7 @@ const postPopOutActivePaymentProductType = (
                     sid,
                     payment_product_type: paymentProductType,
                 },
-                "*",
+                targetOrigin,
             );
         }
     } catch (e) {

--- a/src/subscribe.ts
+++ b/src/subscribe.ts
@@ -34,18 +34,29 @@ export type Subscription = {
 /**
  * Post a message acknowledgement to the checkout iframe.
  */
-const postAck = (source: Window | null, event: MessageEvent) => {
+const postAck = (
+    source: Window | null,
+    event: MessageEvent,
+    targetOrigin: string,
+) => {
     if (event.data.mid && source) {
-        source.postMessage({ ack: event.data.mid }, event.origin || "*");
+        source.postMessage({ ack: event.data.mid }, targetOrigin);
     }
 };
 
 /**
  * Post a SessionLock-event to the checkout iframe.
  */
-export const postSessionLock = (iframe: HTMLIFrameElement, sid: string) => {
+export const postSessionLock = (
+    iframe: HTMLIFrameElement,
+    sid: string,
+    targetOrigin: string,
+) => {
     if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "LockSession", sid }, "*");
+        iframe.contentWindow.postMessage(
+            { type: "LockSession", sid },
+            targetOrigin,
+        );
     }
 };
 
@@ -56,11 +67,12 @@ export const postValidationResult = (
     iframe: HTMLIFrameElement,
     sid: string,
     result: SessionValidationCallback,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
             { type: "ValidationResult", sid, ...result },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -72,11 +84,12 @@ export const postAddressCallbackResult = (
     iframe: HTMLIFrameElement,
     sid: string,
     result: AddressCallbackResult,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
             { type: "AddressCallbackResult", sid, ...result },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -84,9 +97,16 @@ export const postAddressCallbackResult = (
 /**
  * Post RefreshSession-event to the checkout iframe.
  */
-export const postSessionRefresh = (iframe: HTMLIFrameElement, sid: string) => {
+export const postSessionRefresh = (
+    iframe: HTMLIFrameElement,
+    sid: string,
+    targetOrigin: string,
+) => {
     if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "RefreshSession", sid }, "*");
+        iframe.contentWindow.postMessage(
+            { type: "RefreshSession", sid },
+            targetOrigin,
+        );
     }
 };
 
@@ -96,6 +116,7 @@ export const postSessionRefresh = (iframe: HTMLIFrameElement, sid: string) => {
 export const postActivePaymentProductType = (
     iframe: HTMLIFrameElement,
     sid: string,
+    targetOrigin: string,
     paymentProductType?: string,
 ) => {
     if (iframe.contentWindow) {
@@ -105,7 +126,7 @@ export const postActivePaymentProductType = (
                 sid,
                 payment_product_type: paymentProductType,
             },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -116,11 +137,12 @@ export const postActivePaymentProductType = (
 export const postValidatePopOutEvent = (
     iframe: HTMLIFrameElement,
     sid: string,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
             { type: "ValidatingPopOut", sid },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -131,11 +153,12 @@ export const postValidatePopOutEvent = (
 export const postOpenPopOutFailedEvent = (
     iframe: HTMLIFrameElement,
     sid: string,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
             { type: "OpenPopOutFailed", sid },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -143,9 +166,16 @@ export const postOpenPopOutFailedEvent = (
 /**
  * Post OpenedPopOut-event to the checkout iframe.
  */
-export const postOpenPopOutEvent = (iframe: HTMLIFrameElement, sid: string) => {
+export const postOpenPopOutEvent = (
+    iframe: HTMLIFrameElement,
+    sid: string,
+    targetOrigin: string,
+) => {
     if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "OpenedPopOut", sid }, "*");
+        iframe.contentWindow.postMessage(
+            { type: "OpenedPopOut", sid },
+            targetOrigin,
+        );
     }
 };
 
@@ -155,9 +185,13 @@ export const postOpenPopOutEvent = (iframe: HTMLIFrameElement, sid: string) => {
 export const postClosePopOutEvent = (
     iframe: HTMLIFrameElement,
     sid: string,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
-        iframe.contentWindow.postMessage({ type: "ClosedPopOut", sid }, "*");
+        iframe.contentWindow.postMessage(
+            { type: "ClosedPopOut", sid },
+            targetOrigin,
+        );
     }
 };
 
@@ -168,11 +202,12 @@ export const postSetLanguage = (
     iframe: HTMLIFrameElement,
     sid: string,
     language: string,
+    targetOrigin: string,
 ) => {
     if (iframe.contentWindow) {
         iframe.contentWindow.postMessage(
             { type: "SetLanguage", sid, language },
-            "*",
+            targetOrigin,
         );
     }
 };
@@ -200,7 +235,7 @@ export const subscribe = (options: SubscriptionOptions): Subscription => {
             correctSid &&
             correctMessageType
         ) {
-            postAck(checkout.iframe.contentWindow, event);
+            postAck(checkout.iframe.contentWindow, event, endpointUrl.origin);
             handler(event.data, checkout);
         }
     };

--- a/src/url.ts
+++ b/src/url.ts
@@ -107,6 +107,19 @@ const getPopOutUrl = ({
     return `${padTrailingSlash(endpoint)}?${params.toString()}`;
 };
 
+/**
+ * Get the target origin for postMessage calls derived from the endpoint.
+ * Falls back to the default checkout endpoint when none is configured.
+ */
+const getTargetOrigin = (endpoint?: string): string => {
+    const resolvedEndpoint = endpoint || "https://checkout.dintero.com";
+    try {
+        return new URL(resolvedEndpoint).origin;
+    } catch {
+        throw new Error("Invalid endpoint");
+    }
+};
+
 const getHostname = (): string | undefined => {
     try {
         const { hostname } = window.location;
@@ -132,5 +145,6 @@ const hostnameIsTop = (): boolean => {
 export const url = {
     getPopOutUrl,
     getSessionUrl,
+    getTargetOrigin,
     windowLocationAssign,
 };

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -1541,6 +1541,7 @@ describe("dintero.embed", () => {
         expect(popOutModule.postPopOutSessionLock).toBeCalledWith(
             popOutWindow,
             sid,
+            new URL(endpoint).origin,
         );
     });
 
@@ -1624,6 +1625,7 @@ describe("dintero.embed", () => {
         expect(popOutModule.postPopOutSessionRefresh).toBeCalledWith(
             popOutWindow,
             sid,
+            new URL(endpoint).origin,
         );
     });
 
@@ -1709,6 +1711,7 @@ describe("dintero.embed", () => {
         expect(popOutModule.postPopOutActivePaymentProductType).toBeCalledWith(
             popOutWindow,
             sid,
+            new URL(endpoint).origin,
             "generic.creditcard",
         );
     });


### PR DESCRIPTION
Ensure all postMessage targets the checkout origin from the config used when the SDK was initiated.

Ensures that other origins cannot read messages from the SDK to the checkout.