### PR TITLE
fix(sdk): ensure pop out button is hidden when payment is complete

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,7 @@ export interface DinteroCheckoutInstance {
     )[];
     session: Session | undefined;
     popOutWindow: Window | undefined;
+    paymentCompleted: boolean;
 }
 
 export interface DinteroCheckoutOptions {
@@ -207,6 +208,13 @@ const setLanguage: SubscriptionHandler = (
     }
 };
 
+const paymentCompletedEvents = [
+    CheckoutEvents.SessionCancel,
+    CheckoutEvents.SessionPaymentOnHold,
+    CheckoutEvents.SessionPaymentAuthorized,
+    CheckoutEvents.SessionPaymentError,
+];
+
 /**
  * Wrap function with try catch so an error in a single function won't short circuit other code in the current context.
  */
@@ -242,12 +250,6 @@ const createPopOutMessageHandler = (
     };
 
     // Close pop out, and remove SDK rendered button when payment is completed.
-    const paymentCompletedEvents = [
-        CheckoutEvents.SessionCancel,
-        CheckoutEvents.SessionPaymentOnHold,
-        CheckoutEvents.SessionPaymentAuthorized,
-        CheckoutEvents.SessionPaymentError,
-    ];
     const popOutCompletedHandler = {
         internalPopOutHandler: true,
         eventTypes: paymentCompletedEvents,
@@ -467,6 +469,9 @@ const handleShowButton: SubscriptionHandler = (
     event: any,
     checkout: DinteroCheckoutInstance,
 ): void => {
+    if (checkout.paymentCompleted) {
+        return;
+    }
     if (isShowPopOutButton(event)) {
         if (event.session) {
             // Update checkout instance session
@@ -499,6 +504,18 @@ const handleRemoveButton: SubscriptionHandler = (
     if (event.type === InternalCheckoutEvents.HidePopOutButton) {
         removePopOutButton();
     }
+};
+
+/**
+ * Mark the payment as completed and remove the pop out button. Once completed,
+ * handleShowButton ignores any further ShowPopOutButton messages.
+ */
+const handlePaymentCompleted: SubscriptionHandler = (
+    _event,
+    checkout: DinteroCheckoutInstance,
+): void => {
+    checkout.paymentCompleted = true;
+    removePopOutButton();
 };
 
 const cleanUpPopOut = (checkout: DinteroCheckoutInstance) => {
@@ -925,6 +942,10 @@ export const embed = async (
             eventTypes: [CheckoutEvents.AddressCallback],
         },
         {
+            handler: handlePaymentCompleted,
+            eventTypes: paymentCompletedEvents,
+        },
+        {
             handler: handleShowButton as SubscriptionHandler,
             eventTypes: [InternalCheckoutEvents.ShowPopOutButton],
         },
@@ -947,6 +968,7 @@ export const embed = async (
         handlers,
         session: undefined,
         popOutWindow: undefined,
+        paymentCompleted: false,
     };
     const checkoutInstance = checkout;
 

--- a/test/dintero-checkout-web-sdk.test.ts
+++ b/test/dintero-checkout-web-sdk.test.ts
@@ -1149,6 +1149,121 @@ describe("dintero.embed", () => {
         expect(result).to.be.null;
     });
 
+    it("Removes button from DOM when payment is completed", async () => {
+        const script = `
+            // Tell the SDK to create the payment button
+            emit({
+                type: "ShowPopOutButton",
+                top: "0",
+                left: "0",
+                right: "0",
+                styles: {},
+                openLabel: "Pay with Dintero",
+                focusLabel: "Open payment window",
+                closeLabel: "Close payment window",
+                descriptionLabel: "Can't see the payment window?",
+                language: "en",
+                disabled: "false"
+            });
+            window.setTimeout(()=>{
+                emit({
+                    type: "SessionPaymentAuthorized",
+                    href: "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>",
+                    transaction_id: "txn-id",
+                    merchant_reference: "test-1",
+                });
+            }, 50);
+        `;
+
+        vi.spyOn(url, "getSessionUrl").mockImplementation((options) => {
+            return getHtmlBlobUrl(options, script);
+        });
+
+        const result: HTMLElement | null = await new Promise(
+            (resolve, reject) => {
+                dintero
+                    .embed({
+                        sid,
+                        container,
+                        endpoint,
+                        popOut: true,
+                        // Define a payment handler to avoid the followHref fallback.
+                        onPayment: () => {},
+                    })
+                    .catch(reject)
+                    .then(() => {
+                        // Wait for button to be created and removed.
+                        sleep(100).then(() => {
+                            const button = document.getElementById(
+                                "dintero-checkout-sdk-launch-pop-out",
+                            );
+                            resolve(button);
+                        });
+                    });
+            },
+        );
+        expect(result).to.be.null;
+    });
+
+    it("Ignores ShowPopOutButton messages after payment is completed", async () => {
+        // All three messages are posted synchronously, so they are queued on the
+        // parent before the payment event navigates the embedded iframe. Without
+        // the "payment completed" guard, the trailing ShowPopOutButton re-adds the
+        // button; with the guard it is ignored.
+        const showButton = `{
+            type: "ShowPopOutButton",
+            top: "0",
+            left: "0",
+            right: "0",
+            styles: {},
+            openLabel: "Pay with Dintero",
+            focusLabel: "Open payment window",
+            closeLabel: "Close payment window",
+            descriptionLabel: "Can't see the payment window?",
+            language: "en",
+            disabled: "false"
+        }`;
+        const script = `
+            emit(${showButton});
+            emit({
+                type: "SessionPaymentAuthorized",
+                href: "http://redirct_url.test.com?merchant_reference=test-1&transaction_id=<transaction_id>",
+                transaction_id: "txn-id",
+                merchant_reference: "test-1",
+            });
+            emit(${showButton});
+        `;
+
+        vi.spyOn(url, "getSessionUrl").mockImplementation((options) => {
+            return getHtmlBlobUrl(options, script);
+        });
+
+        const result: HTMLElement | null = await new Promise(
+            (resolve, reject) => {
+                dintero
+                    .embed({
+                        sid,
+                        container,
+                        endpoint,
+                        popOut: true,
+                        // Define a payment handler to avoid the followHref fallback.
+                        onPayment: () => {},
+                    })
+                    .catch(reject)
+                    .then(() => {
+                        // Wait until after the second ShowPopOutButton message.
+                        sleep(200).then(() => {
+                            const button = document.getElementById(
+                                "dintero-checkout-sdk-launch-pop-out",
+                            );
+                            resolve(button);
+                        });
+                    });
+            },
+        );
+        expect(result).to.be.null;
+    });
+
     it("Adds backdrop to DOM and opens modal when open button is clicked", async () => {
         const script = `
             // Tell the SDK to create the payment button


### PR DESCRIPTION
Fixes bug observed when testing https://github.com/Dintero/Dintero.Checkout.Web.SDK/pull/619

Ensures that we do not render the pop out button after the payment session has completed and is consumed.